### PR TITLE
fix .dir-locals.el

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -2,5 +2,5 @@
 	((c-file-style . "linux")
 	 (indent-tabs-mode . t)
 	 (tab-width . 8)
-	 (eval . (add-hook 'before-save-hook 'clang-format-buffer))
+	 (eval add-hook 'before-save-hook #'clang-format-buffer nil t)
 	 )))


### PR DESCRIPTION
Fix an wrong setting of .dir-locals.el that runs clang-format on files other than C files.

thanks to <https://emacs.stackexchange.com/questions/12433/use-dir-locals-el-to-append-to-before-save-hook-as-a-buffer-local-variable>.