### PR TITLE
Fix warnings

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -2,5 +2,5 @@
 	((c-file-style . "linux")
 	 (indent-tabs-mode . t)
 	 (tab-width . 8)
-	 (eval . (add-hook 'before-save-hook 'clang-format-buffer))
+	 (eval add-hook 'before-save-hook #'clang-format-buffer nil t)
 	 )))

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS =  -Wall -Wextra
+CFLAGS =  -Wall -Wextra -Werror -std=gnu11
 CFLAGS += -MD
 
 ifeq ($(DEBUG),1)

--- a/src/rw2rvc2.c
+++ b/src/rw2rvc2.c
@@ -1,3 +1,4 @@
+#include <getopt.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -68,7 +69,10 @@ int main(int argc, char **argv)
 			return 3;
 		}
 
-		fread(buf, 1, s, fp);
+		if (fread(buf, 1, s, fp) != s) {
+			fprintf(dbgout, "file read error\n");
+			return 4;
+		}
 		buf[s] = 0;
 	}
 


### PR DESCRIPTION
fix warnings and append options `-Werror` and  `-std=gnu11`.